### PR TITLE
QTNB-12 Create song cache/retriever

### DIFF
--- a/src/main/java/is/yarr/qilletni/auth/PersistentTokenStore.java
+++ b/src/main/java/is/yarr/qilletni/auth/PersistentTokenStore.java
@@ -42,6 +42,7 @@ public class PersistentTokenStore implements TokenStore {
         return refreshRequest.executeAsync().thenApplyAsync(result -> {
             token.setAccessToken(result.getAccessToken());
 
+            // TODO: QTNB-15: Remove explicit use of TokenRepository
             if (token instanceof OAuthToken) {
                 tokenRepository.save((OAuthToken) token);
             } else {

--- a/src/main/java/is/yarr/qilletni/auth/SpotifyAuthHandler.java
+++ b/src/main/java/is/yarr/qilletni/auth/SpotifyAuthHandler.java
@@ -33,7 +33,7 @@ public class SpotifyAuthHandler implements AuthHandler {
     @Override
     public URI beginAuth() {
         return spotifyApiFactory
-                .createAnonApi(REDIRECT_URI)
+                .createRedirectApi(REDIRECT_URI)
                 .authorizationCodeUri()
                 .scope(AuthorizationScope.USER_READ_EMAIL)
                 .build()
@@ -42,7 +42,7 @@ public class SpotifyAuthHandler implements AuthHandler {
 
     @Override
     public CompletableFuture<UserSession> completeAuth(String code) {
-        var spotifyApi = spotifyApiFactory.createAnonApi(REDIRECT_URI);
+        var spotifyApi = spotifyApiFactory.createRedirectApi(REDIRECT_URI);
         var authorizationCodeRequest = spotifyApi.authorizationCode(code).build();
 
         return authorizationCodeRequest.executeAsync()

--- a/src/main/java/is/yarr/qilletni/auth/clientcreds/ClientCredentials.java
+++ b/src/main/java/is/yarr/qilletni/auth/clientcreds/ClientCredentials.java
@@ -1,0 +1,29 @@
+package is.yarr.qilletni.auth.clientcreds;
+
+import java.time.Instant;
+import java.util.Date;
+
+public interface ClientCredentials {
+
+    /**
+     * Gets the access token of the credentials.
+     *
+     * @return The access token
+     */
+    String getAccessToken();
+
+    /**
+     * Gets the time of the expiration of the token.
+     *
+     * @return The expiration time
+     */
+    Instant getExpiry();
+
+    /**
+     * Checks if the token is expired or not.
+     *
+     * @return If the token is expired
+     */
+    boolean isExpired();
+
+}

--- a/src/main/java/is/yarr/qilletni/auth/clientcreds/ClientCredentialsStore.java
+++ b/src/main/java/is/yarr/qilletni/auth/clientcreds/ClientCredentialsStore.java
@@ -1,0 +1,15 @@
+package is.yarr.qilletni.auth.clientcreds;
+
+/**
+ * Stores and manages global {@link ClientCredentials}.
+ */
+public interface ClientCredentialsStore {
+
+    /**
+     * Gets the internal {@link ClientCredentials}, refreshing if necessary.
+     *
+     * @return The valid client credentials
+     */
+    ClientCredentials getClientCredentials();
+
+}

--- a/src/main/java/is/yarr/qilletni/auth/clientcreds/InMemoryClientCredentialsStore.java
+++ b/src/main/java/is/yarr/qilletni/auth/clientcreds/InMemoryClientCredentialsStore.java
@@ -1,0 +1,51 @@
+package is.yarr.qilletni.auth.clientcreds;
+
+import org.apache.hc.core5.http.ParseException;
+import org.springframework.stereotype.Service;
+import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
+
+import java.io.IOException;
+
+/**
+ * Stores a single {@link ClientCredentials} object in memory, lazily performing a synchronous update when it is
+ * expired.
+ */
+@Service
+public class InMemoryClientCredentialsStore implements ClientCredentialsStore {
+
+    private static final String CLIENT_ID = System.getenv("SPOTIFY_CLIENT_ID");
+    private static final String CLIENT_SECRET = System.getenv("SPOTIFY_CLIENT_SECRET");
+
+    private ClientCredentials clientCredentials;
+
+    @Override
+    public ClientCredentials getClientCredentials() {
+        if (clientCredentials == null || clientCredentials.isExpired()) {
+            return requestNewCredentials();
+        }
+
+        return clientCredentials;
+    }
+
+    private synchronized ClientCredentials requestNewCredentials() {
+        if (clientCredentials != null && !clientCredentials.isExpired()) {
+            return clientCredentials;
+        }
+
+        try {
+            var spotifyApi = new SpotifyApi.Builder()
+                    .setClientId(CLIENT_ID)
+                    .setClientSecret(CLIENT_SECRET)
+                    .build();
+
+            se.michaelthelin.spotify.model_objects.credentials.ClientCredentials spotifyClientCredentials = spotifyApi.clientCredentials()
+                    .build()
+                    .execute();
+
+            return clientCredentials = new OAuthClientCredentials(spotifyClientCredentials.getAccessToken(), spotifyClientCredentials.getExpiresIn());
+        } catch (IOException | ParseException | SpotifyWebApiException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/is/yarr/qilletni/auth/clientcreds/OAuthClientCredentials.java
+++ b/src/main/java/is/yarr/qilletni/auth/clientcreds/OAuthClientCredentials.java
@@ -1,0 +1,33 @@
+package is.yarr.qilletni.auth.clientcreds;
+
+import java.time.Instant;
+
+public class OAuthClientCredentials implements ClientCredentials {
+
+    private final String accessToken;
+    private final Instant expiry;
+
+    public OAuthClientCredentials(String accessToken, int expiresIn) {
+        this(accessToken, Instant.now().plusSeconds(expiresIn));
+    }
+
+    public OAuthClientCredentials(String accessToken, Instant expiry) {
+        this.accessToken = accessToken;
+        this.expiry = expiry;
+    }
+
+    @Override
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    @Override
+    public Instant getExpiry() {
+        return expiry;
+    }
+
+    @Override
+    public boolean isExpired() {
+        return Instant.now().isAfter(expiry);
+    }
+}

--- a/src/main/java/is/yarr/qilletni/content/DatabaseSongCache.java
+++ b/src/main/java/is/yarr/qilletni/content/DatabaseSongCache.java
@@ -3,6 +3,8 @@ package is.yarr.qilletni.content;
 import is.yarr.qilletni.database.repositories.external.SongRepository;
 import is.yarr.qilletni.music.Song;
 import is.yarr.qilletni.music.SongId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
@@ -13,6 +15,8 @@ import java.util.concurrent.CompletableFuture;
 
 @Service
 public class DatabaseSongCache implements SongCache {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseSongCache.class);
 
     private final SongRetriever songRetriever;
     private final SongRepository songRepository;
@@ -25,6 +29,7 @@ public class DatabaseSongCache implements SongCache {
     @Async
     @Override
     public CompletableFuture<Song> getSong(SongId songId) {
+        LOGGER.debug("Getting song {}", songId.id());
         var songOptional = songRepository.findById(songId);
 
         return songOptional.map(CompletableFuture::completedFuture)

--- a/src/main/java/is/yarr/qilletni/content/DatabaseSongCache.java
+++ b/src/main/java/is/yarr/qilletni/content/DatabaseSongCache.java
@@ -1,0 +1,52 @@
+package is.yarr.qilletni.content;
+
+import is.yarr.qilletni.database.repositories.external.SongRepository;
+import is.yarr.qilletni.music.Song;
+import is.yarr.qilletni.music.SongId;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class DatabaseSongCache implements SongCache {
+
+    private final SongRetriever songRetriever;
+    private final SongRepository songRepository;
+
+    public DatabaseSongCache(SongRetriever songRetriever, SongRepository songRepository) {
+        this.songRetriever = songRetriever;
+        this.songRepository = songRepository;
+    }
+
+    @Async
+    @Override
+    public CompletableFuture<Song> getSong(SongId songId) {
+        var songOptional = songRepository.findById(songId);
+
+        return songOptional.map(CompletableFuture::completedFuture)
+                .orElseGet(() -> songRetriever.fetchSong(songId)
+                        .thenApply(songRepository::save));
+    }
+
+    @Async
+    @Override
+    public CompletableFuture<List<Song>> getSongs(List<SongId> songIds) {
+        var returningSongs = new ArrayList<Song>();
+
+        var unknownSongs = songIds.parallelStream()
+                .filter(songId -> songRepository.findById(songId)
+                        .map(returningSongs::add)
+                        .isEmpty())
+                .toList();
+
+        return songRetriever.fetchSongs(unknownSongs)
+                .thenApply(retrievedSongs -> {
+                    returningSongs.addAll(retrievedSongs);
+                    return Collections.unmodifiableList(returningSongs);
+                });
+    }
+}

--- a/src/main/java/is/yarr/qilletni/content/SongCache.java
+++ b/src/main/java/is/yarr/qilletni/content/SongCache.java
@@ -1,0 +1,32 @@
+package is.yarr.qilletni.content;
+
+import is.yarr.qilletni.music.Song;
+import is.yarr.qilletni.music.SongId;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Allows for getting songs from either an internal cache or, if needed, from an external source.
+ */
+public interface SongCache {
+
+    /**
+     * Gets a {@link Song} from the internal cache, or if it's not found, from an external source, caching it
+     * afterwards.
+     *
+     * @param songId The ID of the song to get
+     * @return The found song
+     */
+    CompletableFuture<Song> getSong(SongId songId);
+
+    /**
+     * Gets a list of {@link Song}s from the internal cache, or if any not found, from an external source, caching
+     * anything necessary afterwards. The resulting list will be immutable, and order is not guaranteed.
+     *
+     * @param songIds The ID of the songs to get
+     * @return An immutable list of found songs
+     */
+    CompletableFuture<List<Song>> getSongs(List<SongId> songIds);
+
+}

--- a/src/main/java/is/yarr/qilletni/content/SongFactory.java
+++ b/src/main/java/is/yarr/qilletni/content/SongFactory.java
@@ -1,0 +1,54 @@
+package is.yarr.qilletni.content;
+
+import is.yarr.qilletni.music.Song;
+import is.yarr.qilletni.music.SpotifySong;
+import se.michaelthelin.spotify.model_objects.specification.ArtistSimplified;
+import se.michaelthelin.spotify.model_objects.specification.Image;
+import se.michaelthelin.spotify.model_objects.specification.Track;
+
+/**
+ * A factory to create {@link Song} objects from any necessary source objects.
+ */
+public class SongFactory {
+
+    /**
+     * Creates a {@link Song} from a given Spotify {@link Track}.
+     *
+     * @param track The {@link Track} to create the {@link Song} from.
+     * @return The created {@link Song}
+     */
+    public static Song createSong(Track track) {
+        return new SpotifySong(track.getId(), track.getName(), getPrimaryArtist(track), getPrimaryImage(track));
+    }
+
+    /**
+     * Gets the first artist's name from the given {@link Track}, or a placeholder "-" string.
+     *
+     * @param track The track to get the artist from
+     * @return The first artist's name
+     */
+    private static String getPrimaryArtist(Track track) {
+        ArtistSimplified[] artists = track.getArtists();
+        if (artists.length == 0) {
+            return "-";
+        }
+
+        return artists[0].getName();
+    }
+
+    /**
+     * Gets the largest album image from the given {@link Track}, or an empty string.
+     *
+     * @param track The track to get the album art from
+     * @return The largest image's URL
+     */
+    private static String getPrimaryImage(Track track) {
+        Image[] albumImages = track.getAlbum().getImages();
+        if (albumImages.length == 0) {
+            return "";
+        }
+
+        return albumImages[0].getUrl();
+    }
+
+}

--- a/src/main/java/is/yarr/qilletni/content/SongRetriever.java
+++ b/src/main/java/is/yarr/qilletni/content/SongRetriever.java
@@ -1,0 +1,31 @@
+package is.yarr.qilletni.content;
+
+import is.yarr.qilletni.music.Song;
+import is.yarr.qilletni.music.SongId;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Fetches songs directly from an external source, without any cache or restrictions.
+ */
+public interface SongRetriever {
+
+    /**
+     * Fetches a {@link Song} from an external source with the given ID.
+     *
+     * @param songId The ID of the song to fetch
+     * @return The fetched song
+     */
+    CompletableFuture<Song> fetchSong(SongId songId);
+
+    /**
+     * Fetches a list of {@link Song}s from an external source with a given list of IDs. The resulting list will be
+     * immutable, and order is not guaranteed.
+     *
+     * @param songIds The song IDs to fetch
+     * @return An immutable, list of fetched songs
+     */
+    CompletableFuture<List<Song>> fetchSongs(List<SongId> songIds);
+
+}

--- a/src/main/java/is/yarr/qilletni/content/SpotifySongRetriever.java
+++ b/src/main/java/is/yarr/qilletni/content/SpotifySongRetriever.java
@@ -1,0 +1,36 @@
+package is.yarr.qilletni.content;
+
+import is.yarr.qilletni.music.Song;
+import is.yarr.qilletni.music.SongId;
+import is.yarr.qilletni.spotify.SpotifyApiFactory;
+import org.springframework.stereotype.Service;
+import se.michaelthelin.spotify.SpotifyApi;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class SpotifySongRetriever implements SongRetriever {
+
+    private final SpotifyApi spotifyApi;
+
+    public SpotifySongRetriever(SpotifyApiFactory spotifyApiFactory) {
+        this.spotifyApi = spotifyApiFactory.createAnonApi();
+    }
+
+    @Override
+    public CompletableFuture<Song> fetchSong(SongId songId) {
+        return spotifyApi.getTrack(songId.id()).build()
+                .executeAsync()
+                .thenApply(SongFactory::createSong);
+    }
+
+    @Override
+    public CompletableFuture<List<Song>> fetchSongs(List<SongId> songIds) {
+        return spotifyApi.getSeveralTracks(songIds.stream().map(SongId::id).toArray(String[]::new))
+                .build()
+                .executeAsync()
+                .thenApply(tracks -> Arrays.stream(tracks).map(SongFactory::createSong).toList());
+    }
+}

--- a/src/main/java/is/yarr/qilletni/content/SpotifySongRetriever.java
+++ b/src/main/java/is/yarr/qilletni/content/SpotifySongRetriever.java
@@ -3,24 +3,31 @@ package is.yarr.qilletni.content;
 import is.yarr.qilletni.music.Song;
 import is.yarr.qilletni.music.SongId;
 import is.yarr.qilletni.spotify.SpotifyApiFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import se.michaelthelin.spotify.SpotifyApi;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 @Service
 public class SpotifySongRetriever implements SongRetriever {
 
-    private final SpotifyApi spotifyApi;
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpotifySongRetriever.class);
+
+    private final SpotifyApiFactory spotifyApiFactory;
 
     public SpotifySongRetriever(SpotifyApiFactory spotifyApiFactory) {
-        this.spotifyApi = spotifyApiFactory.createAnonApi();
+        this.spotifyApiFactory = spotifyApiFactory;
     }
 
     @Override
     public CompletableFuture<Song> fetchSong(SongId songId) {
+        var spotifyApi = spotifyApiFactory.createClientCredentialsApi();
+
+        LOGGER.debug("Fetching song: {}", songId.id());
         return spotifyApi.getTrack(songId.id()).build()
                 .executeAsync()
                 .thenApply(SongFactory::createSong);
@@ -28,6 +35,9 @@ public class SpotifySongRetriever implements SongRetriever {
 
     @Override
     public CompletableFuture<List<Song>> fetchSongs(List<SongId> songIds) {
+        var spotifyApi = spotifyApiFactory.createClientCredentialsApi();
+
+        LOGGER.debug("Fetching songs: {}", songIds.stream().map(SongId::id).collect(Collectors.joining(", ")));
         return spotifyApi.getSeveralTracks(songIds.stream().map(SongId::id).toArray(String[]::new))
                 .build()
                 .executeAsync()

--- a/src/main/java/is/yarr/qilletni/database/repositories/external/SongRepository.java
+++ b/src/main/java/is/yarr/qilletni/database/repositories/external/SongRepository.java
@@ -1,0 +1,59 @@
+package is.yarr.qilletni.database.repositories.external;
+
+import is.yarr.qilletni.music.Song;
+import is.yarr.qilletni.music.SongId;
+import is.yarr.qilletni.music.SpotifySong;
+import is.yarr.qilletni.music.SpotifySongId;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * An adapter for {@link Song} repositories' operations.
+ */
+@Service
+public class SongRepository {
+
+    private final SpotifySongRepository spotifySongRepository;
+
+    public SongRepository(SpotifySongRepository spotifySongRepository) {
+        this.spotifySongRepository = spotifySongRepository;
+    }
+
+    /**
+     * Finds a {@link Song} from its appropriate repository by the given ID.
+     *
+     * @param songId The ID of the song to find
+     * @return The found song, if any
+     * @throws UnsupportedTypeException If a repository for the given type is not found
+     */
+    public Optional<Song> findById(SongId songId) {
+        if (!(songId instanceof SpotifySongId)) {
+            throw new UnsupportedTypeException(songId);
+        }
+
+        return spotifySongRepository.findById(songId.id())
+                .map(Song.class::cast);
+    }
+
+    /**
+     * Saves a {@link Song} to its appropriate repository.
+     *
+     * @param song The song to save
+     * @return The saved song
+     * @throws UnsupportedTypeException If a repository for the given type is not found
+     */
+    public Song save(Song song) {
+        if (!(song instanceof SpotifySong)) {
+            throw new UnsupportedTypeException(song);
+        }
+
+        return spotifySongRepository.save((SpotifySong) song);
+    }
+
+    static class UnsupportedTypeException extends RuntimeException {
+        UnsupportedTypeException(Object type) {
+            super("Operation is unsupported for a class of type: " + type.getClass().getTypeName());
+        }
+    }
+}

--- a/src/main/java/is/yarr/qilletni/database/repositories/external/SpotifySongRepository.java
+++ b/src/main/java/is/yarr/qilletni/database/repositories/external/SpotifySongRepository.java
@@ -1,0 +1,7 @@
+package is.yarr.qilletni.database.repositories.external;
+
+import is.yarr.qilletni.music.SpotifySong;
+import org.springframework.data.repository.CrudRepository;
+
+public interface SpotifySongRepository extends CrudRepository<SpotifySong, String> {
+}

--- a/src/main/java/is/yarr/qilletni/music/Song.java
+++ b/src/main/java/is/yarr/qilletni/music/Song.java
@@ -10,27 +10,27 @@ public interface Song {
      *
      * @return The song's ID
      */
-    String id();
+    String getId();
 
     /**
      * Gets the song's name.
      *
      * @return The song's name
      */
-    String name();
+    String getName();
 
     /**
      * Gets the primary artist of the song.
      *
      * @return The artist of the song
      */
-    String artist();
+    String getArtist();
 
     /**
      * Gets the direct artwork URL of the song.
      *
      * @return The artwork URL
      */
-    String artworkUrl();
+    String getArtworkUrl();
 
 }

--- a/src/main/java/is/yarr/qilletni/music/SpotifySong.java
+++ b/src/main/java/is/yarr/qilletni/music/SpotifySong.java
@@ -1,12 +1,61 @@
 package is.yarr.qilletni.music;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
 /**
  * An implementation of {@link Song} for the Spotify API.
- *
- * @param id The ID of the song
- * @param name The name of the song
- * @param artist The primary artist of the song
- * @param artworkUrl The artwork URL of the song
  */
-public record SpotifySong(String id, String name, String artist, String artworkUrl) implements Song {
+@Entity(name = "spotify_songs")
+public class SpotifySong implements Song {
+
+    @Id
+    private String id;
+    private String name;
+    private String artist;
+    private String artworkUrl;
+
+    protected SpotifySong() {}
+
+    /**
+     * @param id The ID of the song
+     * @param name The name of the song
+     * @param artist The primary artist of the song
+     * @param artworkUrl The artwork URL of the song
+     */
+    public SpotifySong(String id, String name, String artist, String artworkUrl) {
+        this.id = id;
+        this.name = name;
+        this.artist = artist;
+        this.artworkUrl = artworkUrl;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getArtist() {
+        return artist;
+    }
+
+    @Override
+    public String getArtworkUrl() {
+        return artworkUrl;
+    }
+
+    @Override
+    public String toString() {
+        return "SpotifySong[" +
+                "id=" + id + ", " +
+                "name=" + name + ", " +
+                "artist=" + artist + ", " +
+                "artworkUrl=" + artworkUrl + ']';
+    }
 }

--- a/src/main/java/is/yarr/qilletni/rest/TestEndpoint.java
+++ b/src/main/java/is/yarr/qilletni/rest/TestEndpoint.java
@@ -2,9 +2,13 @@ package is.yarr.qilletni.rest;
 
 import is.yarr.qilletni.auth.AuthHandler;
 import is.yarr.qilletni.auth.SessionHandler;
+import is.yarr.qilletni.content.SongCache;
+import is.yarr.qilletni.music.SpotifySongId;
 import org.apache.hc.core5.http.ParseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMapAdapter;
@@ -23,6 +27,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+/**
+ * This class will be removed when this starts getting more production-ready, do not let the code quality or
+ * functionality of this class reflect on the quality the rest of the project.
+ */
 @RestController
 public class TestEndpoint {
 
@@ -30,10 +38,18 @@ public class TestEndpoint {
 
     private final AuthHandler authHandler;
     private final SessionHandler sessionHandler;
+    private final SongCache songCache;
 
-    public TestEndpoint(AuthHandler authHandler, SessionHandler sessionHandler) {
+    public TestEndpoint(AuthHandler authHandler, SessionHandler sessionHandler, SongCache songCache) {
         this.authHandler = authHandler;
         this.sessionHandler = sessionHandler;
+        this.songCache = songCache;
+    }
+
+    @GetMapping("/demo")
+    public ResponseEntity<?> demo(@Param("id") String id) {
+        var song = songCache.getSong(new SpotifySongId(id)).join();
+        return new ResponseEntity<>(song, HttpStatus.OK);
     }
 
     @GetMapping("/login")

--- a/src/main/java/is/yarr/qilletni/spotify/EnvironmentSpotifyApiFactory.java
+++ b/src/main/java/is/yarr/qilletni/spotify/EnvironmentSpotifyApiFactory.java
@@ -1,10 +1,17 @@
 package is.yarr.qilletni.spotify;
 
 import is.yarr.qilletni.auth.Token;
+import is.yarr.qilletni.auth.clientcreds.ClientCredentialsStore;
+import org.apache.hc.core5.http.ParseException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import se.michaelthelin.spotify.SpotifyApi;
+import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.model_objects.credentials.AuthorizationCodeCredentials;
 
+import javax.annotation.PostConstruct;
+import java.io.IOException;
 import java.net.URI;
 
 @Service
@@ -13,9 +20,21 @@ public class EnvironmentSpotifyApiFactory implements SpotifyApiFactory {
     private static final String CLIENT_ID = System.getenv("SPOTIFY_CLIENT_ID");
     private static final String CLIENT_SECRET = System.getenv("SPOTIFY_CLIENT_SECRET");
 
+    private final ClientCredentialsStore clientCredentialsStore;
+
+    public EnvironmentSpotifyApiFactory(ClientCredentialsStore clientCredentialsStore) {
+        this.clientCredentialsStore = clientCredentialsStore;
+    }
+
     @Override
-    public SpotifyApi createAnonApi() {
-        return createAnonApi(null);
+    public SpotifyApi createClientCredentialsApi() {
+        var clientCredentials = clientCredentialsStore.getClientCredentials();
+
+        return new SpotifyApi.Builder()
+                .setClientId(CLIENT_ID)
+                .setClientSecret(CLIENT_SECRET)
+                .setAccessToken(clientCredentials.getAccessToken())
+                .build();
     }
 
     @Override
@@ -28,7 +47,7 @@ public class EnvironmentSpotifyApiFactory implements SpotifyApiFactory {
     }
 
     @Override
-    public SpotifyApi createAnonApi(URI redirectUri) {
+    public SpotifyApi createRedirectApi(URI redirectUri) {
         return new SpotifyApi.Builder()
                 .setClientId(CLIENT_ID)
                 .setClientSecret(CLIENT_SECRET)

--- a/src/main/java/is/yarr/qilletni/spotify/SpotifyApiFactory.java
+++ b/src/main/java/is/yarr/qilletni/spotify/SpotifyApiFactory.java
@@ -14,11 +14,12 @@ import java.net.URI;
 public interface SpotifyApiFactory {
 
     /**
-     * Creates a {@link SpotifyApi} without any user tokens tied to it.
+     * Creates a {@link SpotifyApi} with client credentials.
+     * @see <a href="https://developer.spotify.com/documentation/general/guides/authorization/client-credentials/">Client Credentials Flow</a>
      *
      * @return The created {@link SpotifyApi}
      */
-    SpotifyApi createAnonApi();
+    SpotifyApi createClientCredentialsApi();
 
     /**
      * Returns a {@link SpotifyApi} to be used to refresh access tokens.
@@ -29,12 +30,13 @@ public interface SpotifyApiFactory {
     SpotifyApi createRefreshApi(String refreshToken);
 
     /**
-     * Creates a {@link SpotifyApi} without any user tokens tied to it, with the (optional) given redirect URI.
+     * Creates a {@link SpotifyApi} without any user tokens tied to it, with the given redirect URI. This should only
+     * be used for authenticating a user.
      *
      * @param redirectUri The redirect URI to include, if any
      * @return The created {@link SpotifyApi}
      */
-    SpotifyApi createAnonApi(@Nullable URI redirectUri);
+    SpotifyApi createRedirectApi(@Nullable URI redirectUri);
 
     /**
      * Creates a {@link SpotifyApi} from a {@link UserInfo}. This is meant to be short-lived, and will


### PR DESCRIPTION
Client Credentials flow has been implemented to assist in song fetching, which should make #13 even easier. This is an in-memory implementation, as I didn't see a reason to have multiple instances of the credentials.

See the comments on the issue for updates on the AC.